### PR TITLE
Configure API URL with environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment configuration
+VITE_API_URL=https://api.example.com

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # J-Mindock-IT-Geek
+
 My work in progress website
+
+## Configuration
+
+Set the API endpoint using `VITE_API_URL` in your `.env` file. The application reads this value using `import.meta.env.VITE_API_URL`.
+
+### Example `.env`
+
+```
+VITE_API_URL=https://api.example.com
+```

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,0 +1,11 @@
+import { API_URL } from '../config';
+
+const Contact = () => {
+  return (
+    <div>
+      <p>API URL: {API_URL}</p>
+    </div>
+  );
+};
+
+export default Contact;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = import.meta.env.VITE_API_URL;


### PR DESCRIPTION
## Summary
- add a simple config module for `VITE_API_URL`
- use the config value in the new `Contact` component
- document environment variable usage
- provide an example `.env`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68518b6de4ac8331b4be4d04d1aa8d55